### PR TITLE
Do not distribute mini CPAN anymore 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.2.0 2019-12-11 15:18:32 +0100 Tobias Oetiker <tobi@oetiker.ch>
+
+ - switch to carton for building dependencies
+
 0.1.5 2019-11-07 12:07:01 +0100 Tobias Oetiker <tobi@oetiker.ch>
 
  - add UTF-8 charset to messages.pot

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.2.1 2019-12-12 13:35:16 +0100 Tobias Oetiker <tobi@oetiker.ch>
+
+ - do not include mini cpan anymore
+
 0.2.0 2019-12-11 15:18:32 +0100 Tobias Oetiker <tobi@oetiker.ch>
 
  - switch to carton for building dependencies

--- a/lib/Mojolicious/Command/Author/generate/automake_app.pm
+++ b/lib/Mojolicious/Command/Author/generate/automake_app.pm
@@ -7,7 +7,7 @@ use Mojo::File;
 use POSIX qw(strftime);
 use Cwd 'getcwd';
 use File::Spec::Functions qw(catdir catfile);
-our $VERSION = '0.1.5';
+our $VERSION = '0.2.1';
 has description => 'Generate Mojolicious web application with Automake';
 has usage => sub { shift->extract_usage };
 

--- a/lib/Mojolicious/Command/Author/generate/automake_app.pm
+++ b/lib/Mojolicious/Command/Author/generate/automake_app.pm
@@ -54,7 +54,7 @@ sub file {
     return {
         'configure.ac' => 'configure.ac',
         'bootstrap' => 'bootstrap',
-        'PERL_MODULES' => 'PERL_MODULES',
+        'cpanfile' => 'cpanfile',
         'VERSION' => 'VERSION',
         'README.md' => 'README.md',
         'AUTHORS' => 'AUTHORS',

--- a/lib/Mojolicious/Command/Author/generate/automake_app/.gitignore
+++ b/lib/Mojolicious/Command/Author/generate/automake_app/.gitignore
@@ -12,6 +12,7 @@ thirdparty/*
 !thirdparty/
 !thirdparty/Makefile.am
 !thirdparty/Makefile.in
+!thirdparty/cpanfile*snapshot
 Build.bat
 .last_cover_stats
 Makefile

--- a/lib/Mojolicious/Command/Author/generate/automake_app/Makefile.am
+++ b/lib/Mojolicious/Command/Author/generate/automake_app/Makefile.am
@@ -13,7 +13,7 @@ SHARE := $(shell test -d share && find share -type d -name ".??*" -prune -o -not
 PERLTESTS := $(shell find t -name "*.t")
 PM := $(shell find lib -name "*.pm")
 
-EXTRA_DIST = VERSION PERL_MODULES COPYRIGHT LICENSE CHANGES AUTHORS bootstrap $(PUB) $(wildcard t/*.t) $(BIN) $(POD) $(TEMPL) $(PERLTESTS) $(SHARE)
+EXTRA_DIST = VERSION cpanfile COPYRIGHT LICENSE CHANGES AUTHORS bootstrap $(PUB) $(wildcard t/*.t) $(BIN) $(POD) $(TEMPL) $(PERLTESTS) $(SHARE)
 
 YEAR := $(shell date +%Y)
 DATE := $(shell date +%Y-%m-%d)

--- a/lib/Mojolicious/Command/Author/generate/automake_app/PERL_MODULES
+++ b/lib/Mojolicious/Command/Author/generate/automake_app/PERL_MODULES
@@ -1,1 +1,0 @@
-Mojolicious

--- a/lib/Mojolicious/Command/Author/generate/automake_app/README.md
+++ b/lib/Mojolicious/Command/Author/generate/automake_app/README.md
@@ -59,13 +59,13 @@ Packaging
 Before releasing, make sure to update `CHANGES`, `VERSION` and run
 `./bootstrap`.
 
-You can also package the application as a nice tar.gz file, it will contain
-a mini copy of CPAN, so that all perl modules can be rebuilt at the
-destination.  If you want to make sure that your project builds with perl
+You can also package the application as a nice tar.gz file, it uses carton to
+install dependent module. If you want to make sure that your project builds with perl
 5.22, make sure to set the `PERL` environment variable to a perl 5.22
 interpreter, make sure to delete any `PERL5LIB` environment variable, and run
-`make clean && make`. Now all modules to build your
-project with any perl from 5.22 on upward will be included in the distribution.
+`make clean && make`. This will cause a `cpanfile-5.22.1.snapshot` file to be included
+with your tar ball, when building the app this snapshot will be used to make sure
+all the right versions of the dependent modules get installed.
 
 ```console
 make dist

--- a/lib/Mojolicious/Command/Author/generate/automake_app/cpanfile
+++ b/lib/Mojolicious/Command/Author/generate/automake_app/cpanfile
@@ -1,0 +1,1 @@
+requires 'Mojolicious';

--- a/lib/Mojolicious/Command/Author/generate/automake_app/thirdparty/Makefile.am
+++ b/lib/Mojolicious/Command/Author/generate/automake_app/thirdparty/Makefile.am
@@ -4,28 +4,47 @@ AUTOMAKE_OPTIONS =  foreign
 
 THIRDPARTY_DIR := $(shell pwd)
 
-THIRDPARTY_DIST := $(shell test -d CPAN && find CPAN -type d -name ".??*" -prune -o -not -name ".*" -a -not -name "*~" -a -not -name "*.tmp"  -a -type f -print )
+# THIRDPARTY_DIST := $(shell test -d cache && find cache -type f )
+CPANSNAPV := cpanfile-$(shell $(PERL) -MConfig -e 'print $$Config{version}').snapshot
 
-EXTRA_DIST = $(THIRDPARTY_DIST) $(wildcard bin/cpanm)
+#EXTRA_DIST = $(THIRDPARTY_DIST) $(wildcard bin/cpanm)
+EXTRA_DIST = bin/cpanm $(wildcard cpanfile*snapshot)
 
 all-local: touch
 
-touch: CPAN/touch ../config.status ../PERL_MODULES
-	$(AM_V_GEN)cat ../PERL_MODULES  | grep -v '#' | PERL_CPANM_HOME=$(THIRDPARTY_DIR) xargs $(PERL) $(THIRDPARTY_DIR)/bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)  --mirror file://$(THIRDPARTY_DIR)/CPAN --mirror-only
-	$(AM_V_GEN)touch touch
+touch:  bin/cpanm $(CPANSNAPV)
+	$(AM_V_at)echo "** Installing Dependencies using cpanm and $(CPANSNAPV)"
+	$(AM_V_at)cp $(CPANSNAPV) ../cpanfile.snapshot
+#	PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR) $(shell test -f ../cpanfile.snapshot && echo --mirror file://$(THIRDPARTY_DIR)/cache) --installdeps ..
+	PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR) --installdeps ..
+	$(AM_V_at)rm -f ../cpanfile.snapshot
+	$(AM_V_at)touch touch
 
-CPAN/touch: ../PERL_MODULES
-	echo "POPULATING OUR LOCAL micro CPAN"
-	$(AM_V_GEN)$(URL_CAT) https://cpanmin.us | PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) - -q --notest --local-lib $(THIRDPARTY_DIR) --save-dists $(THIRDPARTY_DIR)/CPAN --force App::cpanminus
-	$(AM_V_GEN)PERL_CPANM_HOME=$(THIRDPARTY_DIR)/Ore $(THIRDPARTY_DIR)/bin/cpanm -q --notest  --local-lib $(THIRDPARTY_DIR)/Ore File::Which OrePAN
-	$(AM_V_GEN)cat ../PERL_MODULES | grep -v '#' | PERL_CPANM_HOME=$(THIRDPARTY_DIR) xargs $(PERL) $(THIRDPARTY_DIR)/bin/cpanm -q --self-contained --notest --local-lib-contained $(THIRDPARTY_DIR) --save-dists $(THIRDPARTY_DIR)/CPAN
-	- $(AM_V_GEN)PERL5LIB=$(THIRDPARTY_DIR)/Ore/lib/perl5 $(THIRDPARTY_DIR)/Ore/bin/orepan_index.pl --repository $(THIRDPARTY_DIR)/CPAN 2>&1 | egrep -v 'INFO.*Ore|uninitialized|Useless'
-# Ore fails to extract the version form DBI
-	$(AM_V_GEN)gunzip -c CPAN/modules/02packages.details.txt.gz | perl -pe 's{^(DBI\s+)undef(\s+\S+/DBI-)(\d+\.\d+)(\.tar)}{$$1$$3$$2$$3$$4}' |  gzip | cat > x.gz && mv x.gz CPAN/modules/02packages.details.txt.gz
-	$(AM_V_GEN)touch CPAN/touch
+bin/cpanm:
+	$(AM_V_at)mkdir -p bin
+	$(URL_CAT) https://cpanmin.us > bin/cpanm
+	$(AM_V_at)chmod 755 bin/cpanm
+
+$(CPANSNAPV): ../cpanfile
+	$(AM_V_at)echo "** Installing Dependencies using Carton install"
+	$(AM_V_at)test -f $(CPANSNAPV) && cp $(CPANSNAPV) ../cpanfile.snapshot || true
+	$(AM_V_at)test -x carton/bin/carton || $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)/carton Carton
+	$(AM_V_at)PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton install
+	$(AM_V_at)mv ../cpanfile.snapshot $(CPANSNAPV)
+	$(AM_V_at)touch touch
+#	PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton bundle
+#	rm -rf cache
+#	mv ../vendor/cache .
+
+update: $(CPANSNAPV)
+	$(AM_V_at)echo "** Updating Dependencies using Carton update"
+	$(AM_V_at)cp $(CPANSNAPV) ../cpanfile.snapshot
+	$(AM_V_at)PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton update
+	$(AM_V_at)mv ../cpanfile.snapshot $(CPANSNAPV)
 
 clean-local:
-	ls -1 | grep -v Makefile | grep -v bin | grep -v CPAN | xargs rm -rf
+#	ls -1 | grep -v Makefile | grep -v bin | grep -v cache | xargs rm -rf
+	ls -1 | grep -v Makefile | grep -v bin | xargs rm -rf
 
 distclean-local:
 	ls -1 | grep -v Makefile | xargs rm -rf

--- a/lib/Mojolicious/Command/Author/generate/callbackery_app.pm
+++ b/lib/Mojolicious/Command/Author/generate/callbackery_app.pm
@@ -8,7 +8,7 @@ use Mojo::File;
 use POSIX qw(strftime);
 use Cwd 'getcwd';
 use File::Spec::Functions qw(catdir catfile);
-our $VERSION = '0.1.5';
+our $VERSION = '0.2.1';
 has description => 'Generate Callbackery web application with Automake';
 has usage => sub { shift->extract_usage };
 

--- a/lib/Mojolicious/Command/Author/generate/callbackery_app.pm
+++ b/lib/Mojolicious/Command/Author/generate/callbackery_app.pm
@@ -22,7 +22,7 @@ sub file {
     return {
         'configure.ac' => 'configure.ac',
         'bootstrap' => 'bootstrap',
-        'PERL_MODULES' => 'PERL_MODULES',
+        'cpanfile' => 'cpanfile',
         'VERSION' => 'VERSION',
         'README.md' => 'README.md',
         'AUTHORS' => 'AUTHORS',

--- a/lib/Mojolicious/Command/Author/generate/callbackery_app/.gitignore
+++ b/lib/Mojolicious/Command/Author/generate/callbackery_app/.gitignore
@@ -11,6 +11,7 @@ Build
 thirdparty/*
 !thirdparty/
 !thirdparty/Makefile.am
+!thirdparty/cpanfile*snapshot
 !thirdparty/Makefile.in
 Build.bat
 .last_cover_stats

--- a/lib/Mojolicious/Command/Author/generate/callbackery_app/PERL_MODULES
+++ b/lib/Mojolicious/Command/Author/generate/callbackery_app/PERL_MODULES
@@ -1,2 +1,0 @@
-CallBackery
-Mojo::SQLite

--- a/lib/Mojolicious/Command/Author/generate/callbackery_app/README.md
+++ b/lib/Mojolicious/Command/Author/generate/callbackery_app/README.md
@@ -59,13 +59,13 @@ Packaging
 Before releasing, make sure to update `CHANGES`, `VERSION` and run
 `./bootstrap`.
 
-You can also package the application as a nice tar.gz file, it will contain
-a mini copy of CPAN, so that all perl modules can be rebuilt at the
-destination.  If you want to make sure that your project builds with perl
+You can also package the application as a nice tar.gz file, it uses carton to
+install dependent module. If you want to make sure that your project builds with perl
 5.22, make sure to set the `PERL` environment variable to a perl 5.22
 interpreter, make sure to delete any `PERL5LIB` environment variable, and run
-`make clean && make`. Now all modules to build your
-project with any perl from 5.22 on upward will be included in the distribution.
+`make clean && make`. This will cause a `cpanfile-5.22.1.snapshot` file to be included
+with your tar ball, when building the app this snapshot will be used to make sure
+all the right versions of the dependent modules get installed.
 
 ```console
 make dist

--- a/lib/Mojolicious/Command/Author/generate/callbackery_app/cpanfile
+++ b/lib/Mojolicious/Command/Author/generate/callbackery_app/cpanfile
@@ -1,0 +1,2 @@
+requires 'CallBackery';
+requires 'Mojo::SQLite';


### PR DESCRIPTION
... this causes just confusion as module requirements heavily depend on the perl core modules